### PR TITLE
Fix two-card: enviar cc_type_card2 corretamente, corrigir detecção/seleção de bandeira e provider do 2º cartão, removendo deprecated PHP 8.1 e “Affiliation not found”.

### DIFF
--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
@@ -486,35 +486,37 @@ class Request implements BraspaglibRequestInterface, RequestInterface
      */
     public function getPaymentProvider()
     {
+        $ccType = $this->getPaymentData()->getCcType();
 
+        if ($this->getCardType() == 'two_card') {
+            $ccType = $this->cardTwo->getData('cc_type');
+        }
 
-        if ($this->getPaymentData()->getCcType()) {
+        if (!empty($ccType)) {
 
-                
-            if ($this->getConfig()->getIsTestEnvironment()) 
-            return "Simulado";   
+            if ($this->getConfig()->getIsTestEnvironment()) {
+                return 'Simulado';
+            }
 
-            list($provider, $brand) = array_pad(explode('-', $this->getPaymentData()->getCcType(), 2), 2, null);
+            list($provider, $brand) = array_pad(explode('-', $ccType, 2), 2, null);
 
-            if ($provider === "Braspag") {
+            if ($provider === 'Braspag') {
                 $availableTypes = explode(',', $this->getConfig()->getCcTypes());
 
-        
                 foreach ($availableTypes as $key => $availableType) {
-                    $typeDetail = explode("-", $availableType);
+                    $typeDetail = explode('-', $availableType);
                     if (isset($typeDetail[1]) && $typeDetail[1] == $brand) {
                         return $typeDetail[0];
                     }
                 }
 
-
-                return "";
+                return '';
             }
 
             return $provider;
         }
 
-        return "";
+        return '';
     }
 
 
@@ -630,25 +632,33 @@ class Request implements BraspaglibRequestInterface, RequestInterface
      */
     public function getPaymentCreditCardBrand()
     {
-
-        $ccType =  $this->getPaymentData()->getCcType();
+        $ccType = $this->getPaymentData()->getCcType();
 
         if ($this->getCardType() == 'two_card') {
-
             if ($this->cardTwo->getData('cc_token')) {
                 return null;
             } else {
                 $ccType = $this->cardTwo->getData('cc_type');
             }
-
         } elseif ($this->getPaymentData()->getAdditionalInformation('cc_token')) {
             return null;
         }
 
+        if (empty($ccType)) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('Credit card brand is required. Please select your card brand and try again.')
+            );
+        }
 
         list($provider, $brand) = array_pad(explode('-', $ccType, 2), 2, null);
 
-        return ($brand) ? $brand : 'Visa';
+        if (empty($brand)) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('Credit card brand is required. Please select your card brand and try again.')
+            );
+        }
+
+        return $brand;
     }
 
 

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -42,3 +42,6 @@
 "Rules Installments","Regras parcelamento"
 "Currently the Authentication 3DS 2.0 is available only for acquirer Cielo. For 2 card's is not available", "Atualmente a Autenticação 3DS 2.0 está disponível apenas para adquirente Cielo. Para 2 cartões não está disponível"
 "Mark YES in this field so that the installment type is defined by the ISSUER. If NO, the installment type will be RETAILER. Note: Leave the fields below blank to NOT pay in installments with interest.","Marque SIM neste campo para que o tipo de parcelamento seja definido pelo EMISSOR. Caso NÃO, o tipo do parcelamento será LOJISTA. Obs: Deixe em branco os campos abaixo para NÃO parcelar com juros."
+"Please select the card brand to proceed.","Por favor, selecione a bandeira do cartão para continuar."
+"Please select the card brand for the second card to proceed.","Por favor, selecione a bandeira do segundo cartão para continuar."
+"Credit card brand is required. Please select your card brand and try again.","A bandeira do cartão de crédito é obrigatória. Por favor, selecione a bandeira e tente novamente."

--- a/view/frontend/web/js/model/card.js
+++ b/view/frontend/web/js/model/card.js
@@ -225,6 +225,8 @@ define(
 
 				if (card != undefined) {
 					$('.creditcard-type').val("Braspag-"+card.typeName);
+				} else {
+					$('.creditcard-type').val('');
 				}
 			});
 
@@ -246,6 +248,8 @@ define(
 
 				if (card != undefined) {
 					$('.creditcard-type-two').val("Braspag-"+card.typeName);
+				} else {
+					$('.creditcard-type-two').val('');
 				}
 			});
 

--- a/view/frontend/web/js/view/payment/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcard.js
@@ -146,39 +146,36 @@ define(
 
                     $('input#braspag_pagador_creditcard_cc_number').val('');
 
-                    this.creditCardType.subscribe(function () { 
-                        let  value = self.creditCardAmount();
-
-                        if(!Number.isInteger(value))
-                        value = value.replace('.', '').replace(',', '.');
-
-                        self.getCcInstallments(value);
-                    
-
+                    this.creditCardType.subscribe(function () {
+                        self.getCcInstallments();
                     });
 
-                    this.creditCardNumber.subscribe(function (value) { 
-                
+                    this.creditCardNumber.subscribe(function (value) {
+
                         self.showBrandList(false);
-                        
-                        setTimeout(function(){ 
-                             self.oldCardBrand( $('.creditcard-type').val()) 
+
+                        setTimeout(function(){
+                             self.oldCardBrand( $('.creditcard-type').val());
+                             self.loadCreditCardBrands();
                          }, 1000);
 
                          self.oldCardNumber(value);
                      });
 
 
-                    this.selectBrand.subscribe(function (value) { 
+                    this.selectBrand.subscribe(function (value) {
+                        if (!value) return;
 
-                        $('.creditcard-type').val("Braspag-"+value.split('-')[1]);
-                
+                        var brandValue = 'Braspag-' + value.split('-')[1];
+                        $('.creditcard-type').val(brandValue);
+                        self.creditCardType(brandValue);
+
                         if (self.oldCardBrand().split('-')[1] != undefined && self.oldCardBrand().split('-')[1] != value.split('-')[1] ) {
                            $('.card-wrapper .jp-card-container').hide();
                         }else if( self.oldCardBrand().split('-')[1] == value.split('-')[1]) {
                             $('.card-wrapper .jp-card-container').show();
                         }
-                        
+
 
                     });
 
@@ -302,24 +299,24 @@ define(
                 };
                 
                 let towCardComponent = uiRegistry.get("two_card_braspag");
-                
-                if (towCardComponent != undefined) {
-                    
-                    data.additional_data.cc_amount_card2 = towCardComponent.creditCardAmount()
-                    data.additional_data.cc_taxvat_card2 = towCardComponent.creditCardTaxvat()
-                    data.additional_data.cc_exp_year_card2 = towCardComponent.creditCardExpYear()
-                    data.additional_data.cc_exp_month_card2 = towCardComponent.creditCardExpMonth()
-                    data.additional_data.cc_number_card2 = towCardComponent.creditCardNumber()
-                    data.additional_data.cc_owner_card2 = towCardComponent.creditCardOwner()
-                    data.additional_data.cc_installments_card2 = towCardComponent.creditCardInstallments()
-                    data.additional_data.card_cc_token_card2 = towCardComponent.cardTokenValue()
-                    data.additional_data.cc_installments_text_card2 = $('select#braspag_pagador_creditcard_two_card_installments option:selected').text()
 
-                    if (towCardComponent.creditCardType() != undefined) {
-                        data.additional_data.cc_type_card2 = $('.creditcard-type-two').val()
-                    }
+                if (towCardComponent != undefined) {
+
+                    data.additional_data.cc_amount_card2 = towCardComponent.creditCardAmount();
+                    data.additional_data.cc_taxvat_card2 = towCardComponent.creditCardTaxvat();
+                    data.additional_data.cc_exp_year_card2 = towCardComponent.creditCardExpYear();
+                    data.additional_data.cc_exp_month_card2 = towCardComponent.creditCardExpMonth();
+                    data.additional_data.cc_number_card2 = towCardComponent.creditCardNumber();
+                    data.additional_data.cc_cid_card2 = towCardComponent.creditCardVerificationNumber();
+                    data.additional_data.cc_owner_card2 = towCardComponent.creditCardOwner();
+                    data.additional_data.cc_installments_card2 = towCardComponent.creditCardInstallments();
+                    data.additional_data.card_cc_token_card2 = towCardComponent.cardTokenValue();
+                    data.additional_data.cc_installments_text_card2 = $('select#braspag_pagador_creditcard_two_card_installments option:selected').text();
+                    data.additional_data.cc_type_card2 = $('.creditcard-type-two').val();
                 }
-              
+
+
+
 
                 if (sopt.isActive(this.getCode()) && this.isSoptActive()) {
                     data = {
@@ -375,22 +372,27 @@ define(
 
                let  cardType = $('.creditcard-type').val();
 
-                if (cardType != undefined) {
+                if (cardType) {
 
                     self.showBrandList(true);
-                    
+
                     let brandsObject =  this.brandListOptions();
 
                     for (let i = 0, len = brandsObject.length; i < len; i++) {
                         if (!brandsObject[i]) continue;
-                      
+
                        if(cardType.split('-')[1] == brandsObject[i].split('-')[1]) {
                           self.selectBrand(brandsObject[i]);
                           break;
                        }
-    
+
                     }
 
+                } else {
+                    self.selectBrand('');
+                    if (self.creditCardNumber() && self.creditCardNumber().length > 0) {
+                        self.showBrandList(true);
+                    }
                 }
 
                 if(self.creditCardNumber() == undefined || self.creditCardNumber().length == 0)
@@ -760,6 +762,27 @@ define(
                     return false;
                 }
 
+                var ccTypeCard1 = $('.creditcard-type').val();
+                if (!ccTypeCard1 || ccTypeCard1.length === 0) {
+                    self.messageContainer.addErrorMessage({
+                        message: $t('Please select the card brand to proceed.')
+                    });
+                    $('html, body').animate({ scrollTop: $('#' + self.getCode()).offset().top }, 300);
+                    return false;
+                }
+
+                var towCardComponent = uiRegistry.get('two_card_braspag');
+                if (towCardComponent != undefined && towCardComponent.isShowCard2()) {
+                    var ccTypeCard2 = $('.creditcard-type-two').val();
+                    if (!ccTypeCard2 || ccTypeCard2.length === 0) {
+                        self.messageContainer.addErrorMessage({
+                            message: $t('Please select the card brand for the second card to proceed.')
+                        });
+                        $('html, body').animate({ scrollTop: $('#' + self.getCode()).offset().top }, 300);
+                        return false;
+                    }
+                }
+
                 this.isPlaceOrderActionAllowed(false);
 
                 fullScreenLoader.startLoader();
@@ -816,6 +839,7 @@ define(
              * @returns {Object}
              */
             getCcYears: function () {
+                // return window.checkoutConfig.payment.ccform.years[this.getCode()];
                 return window.checkoutConfig.payment.braspag_ccform.years[this.getCode()];
             },
 

--- a/view/frontend/web/js/view/payment/method-renderer/two-card.js
+++ b/view/frontend/web/js/view/payment/method-renderer/two-card.js
@@ -213,20 +213,25 @@ define(
 
                     });
 
-                    this.creditCardNumber.subscribe(function (value) { 
-                
+                    this.creditCardNumber.subscribe(function (value) {
+
                         self.showBrandList(false);
-                        
-                        setTimeout(function(){ 
-                             self.oldCardBrand( $('.creditcard-type').val()) 
+
+                        setTimeout(function(){
+                             self.oldCardBrand( $('.creditcard-type-two').val());
+                             self.loadCreditCardBrands();
                          }, 1000);
 
                          self.oldCardNumber(value);
                      });
 
 
-                    this.selectBrand.subscribe(function (value) { 
-                        $('.creditcard-type-two').val("Braspag-"+value.split('-')[1]);
+                    this.selectBrand.subscribe(function (value) {
+                        if (!value) return;
+
+                        var brandValue = 'Braspag-' + value.split('-')[1];
+                        $('.creditcard-type-two').val(brandValue);
+                        self.creditCardType(brandValue);
 
                         if (self.oldCardBrand().split('-')[1] != undefined && self.oldCardBrand().split('-')[1] != value.split('-')[1] ) {
                             $('.card-wrapper-two-card .jp-card-container').hide();
@@ -274,24 +279,29 @@ define(
  
                 let  cardType = $('.creditcard-type-two').val();
  
-                 if (cardType != undefined) {
- 
+                 if (cardType) {
+
                      self.showBrandList(true);
-                     
+
                      let brandsObject =  this.brandListOptions();
- 
+
                      for (let i = 0, len = brandsObject.length; i < len; i++) {
                          if (!brandsObject[i]) continue;
-                       
+
                         if(cardType.split('-')[1] == brandsObject[i].split('-')[1]) {
                            self.selectBrand(brandsObject[i]);
                            break;
                         }
-     
+
                      }
- 
+
+                 } else {
+                     self.selectBrand('');
+                     if (self.creditCardNumber() && self.creditCardNumber().length > 0) {
+                         self.showBrandList(true);
+                     }
                  }
- 
+
                  if(self.creditCardNumber() == undefined || self.creditCardNumber().length == 0)
                      self.showBrandList(false);
  
@@ -488,62 +498,24 @@ define(
 
             autoSelectBrand: function (data, event) {
                 var self = this;
-                let number = event.target.value;
+                var number = event.target.value;
 
-                if(number.length > 0 && number == $("input#braspag_pagador_creditcard_cc_number").val()){
+                if (number.length > 0 && number === $('input#braspag_pagador_creditcard_cc_number').val()) {
                     self.cardNumberError(true);
                     $(event.target).val('');
-                    setTimeout(() => {self.cardNumberError(false)}, 3000);
+                    setTimeout(function () { self.cardNumberError(false); }, 3000);
                     return;
                 }
 
-                this.creditCardType();
-                
-                if (parseInt(number.substr(0,6)) === 960382) {
-                    $('#braspag_pagador_creditcard_tow_card_cc_type_Credsystem').prop("checked", true);
-                    this.creditCardType('Credsystem-Credsystem');
-                    return;
+                var detectedCard = card.cardFromNumber(number);
+
+                if (detectedCard !== undefined) {
+                    var brandValue = 'Braspag-' + detectedCard.typeName;
+                    $('.creditcard-type-two').val(brandValue);
+                    self.creditCardType(brandValue);
                 }
-                if (parseInt(number.substr(0,1)) === 4) {
-                    $('#braspag_pagador_creditcard_tow_card_cc_type_Rede2-Visa').prop("checked", true);
-                    this.creditCardType('Rede2-Visa');
-                    return;
-                }
-                if (parseInt(number.substr(0,1)) === 5) {
-                    $('#braspag_pagador_creditcard_tow_card_cc_type_Rede2-Master').prop("checked", true);
-                    this.creditCardType('Rede2-Master');
-                    return;
-                }
-                if (parseInt(number.substr(0,2)) === 38 || parseInt(number.substr(0,2)) === 60) {
-                    $('#braspag_pagador_creditcard_tow_card_cc_type_Rede2-Hiper').prop("checked", true);
-                    this.creditCardType('Rede2-Hiper');
-                    return;
-                }
-                if (
-                    parseInt(number.substr(0,2)) === 36 ||
-                    parseInt(number.substr(0,3)) === 301 ||
-                    parseInt(number.substr(0,3)) === 305
-                ) {
-                    $('#braspag_pagador_creditcard_tow_card_cc_type_Rede2-Diners').prop("checked", true);
-                    this.creditCardType('Rede2-Diners');
-                    return;
-                }
-                if (
-                    parseInt(number.substr(0,6)) === 636368 ||
-                    parseInt(number.substr(0,6)) === 636369 ||
-                    parseInt(number.substr(0,6)) === 438935 ||
-                    parseInt(number.substr(0,6)) === 504175 ||
-                    parseInt(number.substr(0,6)) === 451416 ||
-                    parseInt(number.substr(0,6)) === 636297 ||
-                    parseInt(number.substr(0,4)) === 5067 ||
-                    parseInt(number.substr(0,4)) === 4576 ||
-                    parseInt(number.substr(0,4)) === 4011 ||
-                    parseInt(number.substr(0,6)) === 506699
-                ) {
-                    $('#braspag_pagador_creditcard_tow_card_cc_type_Rede2-Elo').prop("checked", true);
-                    this.creditCardType('Rede2-Elo');
-                    return;
-                }
+
+                self.loadCreditCardBrands();
             },
 
             isInstallmentsActive: function () {
@@ -669,6 +641,7 @@ define(
              * @returns {Object}
              */
             getCcYears: function () {
+                // return window.checkoutConfig.payment.ccform.years[this.getCodeMethod()];
                 return window.checkoutConfig.payment.braspag_ccform.years[this.getCodeMethod()];
             },
 

--- a/view/frontend/web/template/payment/two-card.html
+++ b/view/frontend/web/template/payment/two-card.html
@@ -153,8 +153,8 @@
             <ul class="credit-card-types-card">
                 <!-- ko foreach: {data: brandListOptions(), as: 'brand'} -->
                       <li>
-                           <label data-bind="attr: {'for': brand.toLowerCase()}">
-                              <input type="radio" data-bind="value: $data, checked: $parent.selectBrand, attr: { name: 'imageListRadio', id: brand.toLowerCase() }" />
+                           <label data-bind="attr: {'for': 'card2_' + brand.toLowerCase()}">
+                              <input type="radio" data-bind="value: $data, checked: $parent.selectBrand, attr: { name: 'imageListRadioCard2', id: 'card2_' + brand.toLowerCase() }" />
                               <img data-bind="attr: { src: $parent.brandImage(brand), alt: brand }, css: { 'selected-card': $parent.selectBrand() === $data }" style="width:46px; height: 30px;" />
                            </label>
                          


### PR DESCRIPTION
1 - Corrigido fluxo de pagamento com dois cartões garantindo envio consistente da bandeira do cartão 2 (cc_type_card2) em auto-detecção e seleção manual.

2 - Removido fallback silencioso de bandeira (ex: “Visa”) e adicionada validação amigável no backend quando cc_type estiver vazio/nulo (evita deprecated do PHP 8.1).

3 - Ajustado getPaymentProvider() para ler o cc_type do cartão correto no cenário two-card (corrige “Affiliation not found”).

4 - Padronizada detecção de bandeira do cartão 2 usando card.js (elimina BINs hardcoded dependentes de adquirente).

5 - Corrigidos radio buttons do cartão 2 (name/id únicos) para não interferirem no cartão 1.

6 - Implementada limpeza de estado quando detecção falha, evitando bandeira anterior persistente, e adicionadas validações no checkout para impedir finalização sem bandeira.

7 - Incluídas traduções pt_BR e en_US para novas mensagens.