### PR TITLE
Fix customer identity type based on alphanumeric CNPJs.

### DIFF
--- a/Gateway/Transaction/Boleto/Resource/Send/Request.php
+++ b/Gateway/Transaction/Boleto/Resource/Send/Request.php
@@ -149,7 +149,7 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
         $customerIdenty = $this->getCustomerIdentity();
 
         if ($customerIdenty) {
-           return (strlen((string) preg_replace('/[^0-9]/', '', $customerIdenty)) > 11) ? 'CNPJ' : 'CPF';
+            return $this->helperData->getCustomerEntityType($customerIdenty);
         }
 
         return '';

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
@@ -202,7 +202,7 @@ class Request implements BraspaglibRequestInterface, RequestInterface
         $customerIdenty = $this->getCustomerIdentity();
 
         if ($customerIdenty) {
-            return (strlen((string) preg_replace('/[^0-9]/', '', $customerIdenty)) > 11) ? 'CNPJ' : 'CPF';
+            return $this->helperData->getCustomerEntityType($customerIdenty);
         }
 
         return '';

--- a/Gateway/Transaction/Pix/Resource/Send/Request.php
+++ b/Gateway/Transaction/Pix/Resource/Send/Request.php
@@ -146,7 +146,7 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
         $customerIdenty = $this->getCustomerIdentity();
 
         if ($customerIdenty) {
-           return (strlen((string) preg_replace('/[^0-9]/', '', $customerIdenty)) > 11) ? 'CNPJ' : 'CPF';
+            return $this->helperData->getCustomerEntityType($customerIdenty);
         }
 
         return '';

--- a/Gateway/Transaction/Voucher/Resource/Order/Request.php
+++ b/Gateway/Transaction/Voucher/Resource/Order/Request.php
@@ -161,8 +161,8 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
      */
     public function getCustomerIdentityType()
     {
-        $identity = (string) preg_replace('/[^0-9]/', '', $this->getCustomerIdentity());
-        return (strlen($identity) > 11) ? 'CNPJ' : 'CPF';
+        $identity = $this->getCustomerIdentity();
+        return $this->helperData->getCustomerEntityType($identity);
     }
 
     /**

--- a/Gateway/Transaction/Wallet/Resource/Send/Request.php
+++ b/Gateway/Transaction/Wallet/Resource/Send/Request.php
@@ -140,7 +140,7 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
         $customerIdenty = $this->getCustomerIdentity();
 
         if ($customerIdenty) {
-           return (strlen((string) preg_replace('/[^0-9]/', '', $customerIdenty)) > 11) ? 'CNPJ' : 'CPF';
+            return $this->helperData->getCustomerEntityType($customerIdenty);
         }
     }
        

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -45,4 +45,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         return null;
     }
+
+    /**
+     * @param $taxvat
+     * @return string
+     */
+    public function getCustomerEntityType($taxvat)
+    {
+        return (strlen((string) $taxvat)) > 11 ? 'CNPJ' : 'CPF';
+    }
 }


### PR DESCRIPTION
Criado função no Helper/Data.php para centralizar e fixar o retorno do tipo do CustomerIdentityType, CNPJs alfanuméricos serão implementados pela Receita Federal em julho de 2026, getCustomerIdentity() já retorna um alfanumérico, getCustomerEntityType foi colocada no Helper para facilitar, já que era repetido em diversos Resources, como estava antes, a função getCustomerIdentityType de cada Resource, removia as letras, o que fazia com que CNPJs alfanuméricos fossem identificados como CPF.